### PR TITLE
Multiplication fix

### DIFF
--- a/include/FixedPoint/MultiwordIntegerSpecialization.hpp
+++ b/include/FixedPoint/MultiwordIntegerSpecialization.hpp
@@ -99,7 +99,8 @@ public:
     mul(MultiwordInteger<otherSize, storageType> const &o,
         MultiwordInteger<outSize,   storageType>       *out) const {
         if (otherSize == 1) {
-            bigType c = signedType(s[0]) * signedType(o.s[0]);
+            typename std::make_signed<bigType>::type c = signedType(s[0]);
+            c *= signedType(o.s[0]);
             *out = MultiwordInteger<outSize, storageType>(storageType(c));
             if (outSize > 1) {
                 out->s[1] = c >> storageSize;


### PR DESCRIPTION
Have to explicitly cast at least one number to get the next larger type
as multiplication result, so do that.